### PR TITLE
Remove redundant nil checks

### DIFF
--- a/backend/yandex/api/client.go
+++ b/backend/yandex/api/client.go
@@ -67,10 +67,8 @@ var defaultErrorHandler ErrorHandler = func(resp *http.Response) error {
 func (HTTPRequest *HTTPRequest) run(client *Client) ([]byte, error) {
 	var err error
 	values := make(url.Values)
-	if HTTPRequest.Parameters != nil {
-		for k, v := range HTTPRequest.Parameters {
-			values.Set(k, fmt.Sprintf("%v", v))
-		}
+	for k, v := range HTTPRequest.Parameters {
+		values.Set(k, fmt.Sprintf("%v", v))
 	}
 
 	var req *http.Request


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)